### PR TITLE
Renombradas varias clases conforme a la guía de estilo de plugins de Leaflet

### DIFF
--- a/examples/pnoa.html
+++ b/examples/pnoa.html
@@ -27,29 +27,33 @@
 	<body>
 		<div id="map"></div>
 		<script>
-		var map = L.map('map', {
-			zoomControl:true, 
-			maxZoom:20,
-			layers:[Spain_UnidadAdministrativa,Spain_PNOA_Ortoimagen]
-		}).fitBounds([[24.9300000311,-19.6],[46.0700000311,5.6]]);
-		
+		// L.control.layers will need a dictionary of layers
 		var baselayers = {
-			
-				"PNOA Mosaico": Spain_PNOA_Mosaico,
-				"PNOA Máx. Actualidad": Spain_PNOA_Ortoimagen,
-				"PNOA 2010": Spain_PNOA_2010,
-				"PNOA 2009": Spain_PNOA_2009,
-				"PNOA 2008": Spain_PNOA_2008,
-				"PNOA 2007": Spain_PNOA_2007,
-				"PNOA 2006": Spain_PNOA_2006,
-				"PNOA 2005": Spain_PNOA_2005,
-				"PNOA 2004": Spain_PNOA_2004
-			
+			"PNOA Máx. Actualidad": L.tileLayer.wms.spain.pnoa.ortoimagen(),
+			"PNOA Mosaico": L.tileLayer.wms.spain.pnoa.mosaico(),
+			"PNOA 2010": L.tileLayer.wms.spain.pnoa.historico(2010),
+			"PNOA 2009": L.tileLayer.wms.spain.pnoa.historico(2009),
+			"PNOA 2008": L.tileLayer.wms.spain.pnoa.historico(2008),
+			"PNOA 2007": L.tileLayer.wms.spain.pnoa.historico(2007),
+			"PNOA 2006": L.tileLayer.wms.spain.pnoa.historico(2006),
+			"PNOA 2005": L.tileLayer.wms.spain.pnoa.historico(2005),
+			"PNOA 2004": L.tileLayer.wms.spain.pnoa.historico(2004)
 		};
 
 		var overlayers = {
-			"Unidades administrativas": Spain_UnidadAdministrativa
+			"Unidades administrativas": L.tileLayer.wms.spain.unidadadministrativa()
 		};
+
+		// Map init will need a plain array of layers with the layers to load
+		//   initially
+		var layersArray = [ baselayers['PNOA Máx. Actualidad'] ];
+
+		var map = L.map('map', {
+			zoomControl:true,
+			maxZoom:20,
+			layers: layersArray
+		}).fitBounds([[24.9300000311,-19.6],[46.0700000311,5.6]]);
+
 		
 		L.control.layers(baselayers, overlayers,{collapsed:false}).addTo(map);
 		L.control.scale({options: {position: 'bottomleft',maxWidth: 100,metric: true,imperial: false,updateWhenIdle: false}}).addTo(map);

--- a/src/Leaflet.Spain.WMS.js
+++ b/src/Leaflet.Spain.WMS.js
@@ -1,90 +1,97 @@
 //Spain
 
+L.TileLayer.WMS.Spain = {};	// Classes
+
+L.tileLayer.wms.spain = {};	// Factories
+
+// PNOA
+
+L.TileLayer.WMS.Spain.PNOA = L.TileLayer.WMS.extend({
+	options: {
+		service: 'WMS',
+		request: 'GetMap',
+		version: '1.1.1',
+		format: 'image/png',
+		transparent: false,
+		continuousWorld : true,
+		attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
+	}
+});
+
+// L.TileLayer.WMS.Spain.PNOA.mergeOptions();
+
+L.tileLayer.wms.spain.pnoa = function(url, options) {
+	return new L.TileLayer.WMS.Spain.PNOA(url, options);
+}
+
 // Ortofotos del PNOA. Máxima actualidad
 // Capabilities:http://www.ign.es/wms-inspire/pnoa-ma?request=GetCapabilities&service=WMS
-// El servicio permite visualizar las ortofotos de máxima actualidad del Plan Nacional de Ortofotografía Aérea 
-// (PNOA) a partir de una escala aproximada 1:70 000. Para escalas menores (menos detalladas) se visualizan las 
+// El servicio permite visualizar las ortofotos de máxima actualidad del Plan Nacional de Ortofotografía Aérea
+// (PNOA) a partir de una escala aproximada 1:70 000. Para escalas menores (menos detalladas) se visualizan las
 // imágenes de satélite Spot5.
 
-var Spain_PNOA_Ortoimagen = L.tileLayer.wms('http://www.ign.es/wms-inspire/pnoa-ma', {
-	layers: 'OI.OrthoimageCoverage',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
+L.TileLayer.WMS.Spain.PNOA.Ortoimagen = L.TileLayer.WMS.Spain.PNOA.extend({
+	initialize: function(options) {
+		L.TileLayer.WMS.Spain.PNOA.prototype.initialize.call(this,
+			'http://www.ign.es/wms-inspire/pnoa-ma',
+			L.extend({ layers: 'OI.OrthoimageCoverage' }, options || {})
+		);
+	}
 });
-var Spain_PNOA_Mosaico = L.tileLayer.wms('http://www.ign.es/wms-inspire/pnoa-ma', {
-	layers: 'OI.MosaicElement',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
+
+L.tileLayer.wms.spain.pnoa.ortoimagen = function(options) {
+	return new L.TileLayer.WMS.Spain.PNOA.Ortoimagen(options);
+}
+
+L.TileLayer.WMS.Spain.PNOA.Mosaico = L.TileLayer.WMS.Spain.PNOA.extend({
+	initialize: function(options) {
+		L.TileLayer.WMS.Spain.PNOA.prototype.initialize.call(this,
+			'http://www.ign.es/wms-inspire/pnoa-ma',
+			L.extend({ layers: 'OI.MosaicElement' }, options)
+		);
+	}
 });
+
+L.tileLayer.wms.spain.pnoa.mosaico = function(options){
+	return new L.TileLayer.WMS.Spain.PNOA.Mosaico(options);
+}
 
 // Ortofotos históricas del PNOA
 // Capabilities: http://www.ign.es/wms/pnoa-historico?request=GetCapabilities&service=WMS
 
-var Spain_PNOA_2004 = L.tileLayer.wms('http://www.ign.es/wms/pnoa-historico', {
-	layers: 'PNOA2004',			format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
+L.TileLayer.WMS.Spain.PNOA.Historico = L.TileLayer.WMS.Spain.PNOA.extend({
+	initialize: function(year, options) {
+		L.TileLayer.WMS.Spain.PNOA.prototype.initialize.call(this,
+			'http://www.ign.es/wms/pnoa-historico',
+			L.extend({ layers: 'PNOA' + year }, options)
+		);
+	}
 });
-var Spain_PNOA_2005 = L.tileLayer.wms('http://www.ign.es/wms/pnoa-historico', {
-	layers: 'PNOA2005',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
-});
-var Spain_PNOA_2006 = L.tileLayer.wms('http://www.ign.es/wms/pnoa-historico', {
-	layers: 'PNOA2006',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
-});
-var Spain_PNOA_2007 = L.tileLayer.wms('http://www.ign.es/wms/pnoa-historico', {
-	layers: 'PNOA2007',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
-});
-var Spain_PNOA_2008 = L.tileLayer.wms('http://www.ign.es/wms/pnoa-historico', {
-	layers: 'PNOA2008',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
-});
-var Spain_PNOA_2009 = L.tileLayer.wms('http://www.ign.es/wms/pnoa-historico', {
-	layers: 'PNOA2009',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
-});
-var Spain_PNOA_2010 = L.tileLayer.wms('http://www.ign.es/wms/pnoa-historico', {
-	layers: 'PNOA2010',
-	format: 'image/png',
-	transparent: false,
-	continuousWorld : true,
-	attribution: 'PNOA cedido por © <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
-});
+
+L.tileLayer.wms.spain.pnoa.historico = function(year, options) {
+	return new L.TileLayer.WMS.Spain.PNOA.Historico(year, options);
+}
 
 // Unidades administrativas
 // Capabilities:http://www.ign.es/wms-inspire/unidades-administrativas?request=GetCapabilities&service=WMS
 // Unidades administrativas tres niveles de administración (comunidad autónoma, provincia y municipio).
 
-var Spain_UnidadAdministrativa = L.tileLayer.wms('http://www.ign.es/wms-inspire/unidades-administrativas', {
-	layers: 'AU.AdministrativeUnit',
-	format: 'image/png',
-	transparent: true,
-	continuousWorld : true,
-	attribution: '© <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
-
+L.TileLayer.WMS.Spain.UnidadAdministrativa = L.TileLayer.WMS.extend({
+	initialize: function(options) {
+		L.TileLayer.WMS.Spain.PNOA.prototype.initialize.call(this, 'http://www.ign.es/wms-inspire/unidades-administrativas', options );
+	},
+	options: {
+		layers: 'AU.AdministrativeUnit',
+		format: 'image/png',
+		transparent: false,
+		continuousWorld : true,
+		attribution: '© <a href="http://www.ign.es/ign/main/index.do" target="_blank">Instituto Geográfico Nacional de España</a>'
+	}
 });
+
+L.tileLayer.wms.spain.unidadadministrativa = function(options) {
+	return new L.TileLayer.WMS.Spain.UnidadAdministrativa(options || {});
+}
 
 // Cartografía raster IGN.
 // Capabilities: http://www.ign.es/wms-inspire/mapa-raster?request=GetCapabilities&service=WMS
@@ -162,6 +169,8 @@ var Spain_Catastro = L.tileLayer.wms('http://ovc.catastro.meh.es/Cartografia/WMS
 });
 
 // ANDALUCIA
+
+L.TileLayer.WMS.Andalucia = {};
 
 // Callejero Digital de Andalucía Unificado
 // Capabilities: http://www.callejerodeandalucia.es/servicios/cdau/wms?request=GetCapabilities&service=WMS


### PR DESCRIPTION
Exponer variables globales en un plugin de Leaflet (como se está haciendo ahora) es una mala práctica. Además, los nombres de las clases deben seguir una estructura en árbol, que muestre claramente las dependencias.

Véase https://github.com/Leaflet/Leaflet/blob/master/PLUGIN-GUIDE.md#plugin-api

He renombrado las clases de las capas de PNOA, añadiendo clases y fábricas con los nombres apropiados. El resto (IGN base, andalucía) quedan como ejercicio al lector :-D
